### PR TITLE
feat: add DeskThing-ClaudeStatus (Claude Code session & usage monitor)

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -35,6 +35,7 @@ const COMMUNITY_REPOS: GitRepoUrl[] = [
   'https://github.com/Jarsa132/deskthing-volctrl',
   'https://github.com/nwo122383/sonos-webapp',
   'https://github.com/RandomDebugGuy/DeskThing-GMP',
+  'https://github.com/acidkill/DeskThing-ClaudeStatus',
 ]
 
 const ensureCLIDownload = async () => {


### PR DESCRIPTION
## App: Claude Status for DeskThing

Adds **DeskThing-ClaudeStatus** to the community apps listing.

### What it does

Live Claude Code session (5h) and weekly (7d) utilisation meters for the Spotify Car Thing. Reads the OAuth token from `~/.claude/.credentials.json`, polls `POST /v1/messages` with a one-token Haiku call to parse `anthropic-ratelimit-unified-*` response headers, and drives a 20×20 pixel-art robot mascot through mood tiers (idle → active → busy → frantic) based on rate-of-change of session usage.

### Checklist

- [x] Public GitHub repository: https://github.com/acidkill/DeskThing-ClaudeStatus
- [x] GitHub Release exists with installable ZIP + `latest.json`: https://github.com/acidkill/DeskThing-ClaudeStatus/releases/tag/v0.4.0
- [x] `deskthing/manifest.json` with correct `id`, `label`, `version`, `updateUrl`, `compatible_server/client: [11]`
- [x] Apache-2.0 — all code and sprite assets original work, no proprietary art
- [x] README with setup, settings reference, troubleshooting

### Manifest
```json
{
  "id": "claude-status",
  "label": "Claude Status",
  "version": "0.4.0",
  "compatible_server": [11],
  "compatible_client": [11],
  "updateUrl": "https://github.com/acidkill/DeskThing-ClaudeStatus/releases/latest/download/latest.json"
}
```