### PR TITLE
Fix Spotify rate limiting: honor Retry-After globally, stop redundant calls

### DIFF
--- a/spotify/server/initializer.ts
+++ b/spotify/server/initializer.ts
@@ -39,7 +39,10 @@ DeskThing.on(SongEvent.GET, async (data) => {
       musicStore.returnSongData();
       break;
     case AUDIO_REQUESTS.REFRESH:
-      await musicStore.checkForRefresh();
+      // A truthy payload means the server knows playback just changed — a
+      // track boundary or a skip — and needs an answer from Spotify rather
+      // than a coalesced one describing the track we are trying to leave.
+      await musicStore.checkForRefresh({ forceRefresh: Boolean(data.payload) });
       break;
   }
 });

--- a/spotify/server/spotify/queueStore.ts
+++ b/spotify/server/spotify/queueStore.ts
@@ -16,7 +16,10 @@ export class QueueStore extends EventEmitter<queueStoreEvents> {
   private rawQueueData: QueueResponse | undefined;
   private queueData: SongQueue | undefined;
   private lastFetchTime: number = 0;
-  private readonly CACHE_DURATION = 10000; // Cache expires after 10 seconds
+  // Longer than the 15s poll interval on purpose: a 10s TTL under a 15s poll
+  // guaranteed every cycle was a live API call. Queue edits from this app
+  // bypass the cache anyway, so the only cost is a slightly stale Up Next.
+  private readonly CACHE_DURATION = 45000;
 
   constructor(spotifyApi: SpotifyStore) {
     super();

--- a/spotify/server/spotify/songStore.ts
+++ b/spotify/server/spotify/songStore.ts
@@ -37,6 +37,8 @@ export class SongStore extends EventEmitter<songStoreEvents> {
    */
   private likedMemo: { id: string; value: boolean; timestamp: number } | null = null;
   private static readonly LIKED_MEMO_TTL_MS = 5 * 60 * 1000;
+  /** How long to sit on a failed lookup before trying that track again. */
+  private static readonly LIKED_MEMO_FAILURE_TTL_MS = 60 * 1000;
 
   constructor(spotifyApi: SpotifyStore, deviceStore: DeviceStore) {
     super();
@@ -44,9 +46,9 @@ export class SongStore extends EventEmitter<songStoreEvents> {
     this.deviceStore = deviceStore;
   }
 
-  async getCurrentPlayback({ signal }: { signal?: AbortSignal } = {}): Promise<PlayerResponse | undefined> {
+  async getCurrentPlayback({ signal, forceRefresh }: { signal?: AbortSignal; forceRefresh?: boolean } = {}): Promise<PlayerResponse | undefined> {
     try {
-      const currentPlayback = await this.spotifyApi.getCurrentPlayback({ signal });
+      const currentPlayback = await this.spotifyApi.getCurrentPlayback({ signal, forceRefresh });
       if (!currentPlayback) return undefined;
 
       this.deviceStore.addDevicesFromPlayback(currentPlayback);
@@ -73,9 +75,23 @@ export class SongStore extends EventEmitter<songStoreEvents> {
         return this.likedMemo.value;
       }
       const isLiked = await this.spotifyApi.checkLiked(id);
-      // A gated/failed request resolves undefined — keep the previous memo and
-      // report unknown-as-false rather than caching a wrong answer.
-      if (!Array.isArray(isLiked)) return this.likedMemo?.value ?? false;
+      // A gated/failed request resolves undefined — keep the previous answer
+      // and report unknown-as-false rather than caching a wrong one.
+      //
+      // Remember the failure for a short while even so. This endpoint can fail
+      // persistently (a 403 when the token lacks user-library-read, which no
+      // amount of retrying fixes), and without a negative memo every single
+      // emit re-issues a call that cannot succeed — the exact traffic the memo
+      // exists to remove, and pressure we can't afford next to a rate limit.
+      if (!Array.isArray(isLiked)) {
+        const known = this.likedMemo?.id === id ? this.likedMemo.value : false;
+        this.likedMemo = {
+          id,
+          value: known,
+          timestamp: Date.now() - SongStore.LIKED_MEMO_TTL_MS + SongStore.LIKED_MEMO_FAILURE_TTL_MS
+        };
+        return known;
+      }
       this.likedMemo = { id, value: isLiked[0] == true, timestamp: Date.now() };
       this.emit("iconUpdate", {
         id: "like_song",
@@ -89,7 +105,13 @@ export class SongStore extends EventEmitter<songStoreEvents> {
     }
   }
 
-  async checkForRefresh() {
+  /**
+   * @param forceRefresh Skip request coalescing and ask Spotify directly. Set
+   * this when the caller has reason to believe playback just changed — at a
+   * track boundary, or right after a skip — where a coalesced answer is the
+   * previous track by definition.
+   */
+  async checkForRefresh({ forceRefresh }: { forceRefresh?: boolean } = {}) {
     if (this.is_refreshing.state && Date.now() - this.is_refreshing.timestamp < 5000) {
       console.debug(
         `SongStore: checkForRefresh - already refreshing, skipping...`
@@ -104,7 +126,7 @@ export class SongStore extends EventEmitter<songStoreEvents> {
       const timeoutId = setTimeout(() => controller.abort(), 5000);
 
       try {
-        const playback = await this.getCurrentPlayback({ signal: controller.signal });
+        const playback = await this.getCurrentPlayback({ signal: controller.signal, forceRefresh });
 
         // Clear timeout as request completed
         clearTimeout(timeoutId);

--- a/spotify/server/spotify/songStore.ts
+++ b/spotify/server/spotify/songStore.ts
@@ -28,6 +28,15 @@ export class SongStore extends EventEmitter<songStoreEvents> {
     shuffleState: false,
   };
   private is_refreshing: { state: boolean; timestamp: number } = { state: false, timestamp: 0 };
+  /**
+   * Liked-state memo. The refresh cycle treats any progress advance as a state
+   * change, so without this the /me/tracks/contains call fires on EVERY poll —
+   * a third of all API traffic, and the endpoint that historically absorbed the
+   * rate-limit bans. A track's liked state only changes from this app via
+   * likeSong (which invalidates it), so a short TTL is safe.
+   */
+  private likedMemo: { id: string; value: boolean; timestamp: number } | null = null;
+  private static readonly LIKED_MEMO_TTL_MS = 5 * 60 * 1000;
 
   constructor(spotifyApi: SpotifyStore, deviceStore: DeviceStore) {
     super();
@@ -56,7 +65,18 @@ export class SongStore extends EventEmitter<songStoreEvents> {
   async checkLiked(id: string): Promise<boolean> {
     try {
       if (!id) return false;
+      if (
+        this.likedMemo &&
+        this.likedMemo.id === id &&
+        Date.now() - this.likedMemo.timestamp < SongStore.LIKED_MEMO_TTL_MS
+      ) {
+        return this.likedMemo.value;
+      }
       const isLiked = await this.spotifyApi.checkLiked(id);
+      // A gated/failed request resolves undefined — keep the previous memo and
+      // report unknown-as-false rather than caching a wrong answer.
+      if (!Array.isArray(isLiked)) return this.likedMemo?.value ?? false;
+      this.likedMemo = { id, value: isLiked[0] == true, timestamp: Date.now() };
       this.emit("iconUpdate", {
         id: "like_song",
         state: isLiked[0] == true ? "liked" : "",
@@ -355,12 +375,14 @@ export class SongStore extends EventEmitter<songStoreEvents> {
         console.log("Disliking the current song");
         await this.spotifyApi.likeSong(songId, false);
         console.log("Successfully unliked song: " + songId);
+        this.likedMemo = { id: songId, value: false, timestamp: Date.now() };
         this.emit("iconUpdate", { id: "like_song", state: "" });
         return;
       } else {
         console.log("Liking the current song", isLiked);
         await this.spotifyApi.likeSong(songId, true);
         console.log("Successfully liked song: " + songId);
+        this.likedMemo = { id: songId, value: true, timestamp: Date.now() };
         this.emit("iconUpdate", { id: "like_song", state: "liked" });
       }
     } catch (error) {

--- a/spotify/server/spotify/spotifyStore.ts
+++ b/spotify/server/spotify/spotifyStore.ts
@@ -31,7 +31,15 @@ export class SpotifyStore {
   private requestQueue: Record<string, QueueEntry | undefined> = {};
   private cacheExpiration = 3 * 1000; // 3 seconds default expiration
   private access_token: string | undefined = undefined;
-  private rateLimitDelay = 0;
+  /**
+   * Epoch ms until which every request holds off. Spotify's 429 Retry-After
+   * applies to the whole app, not one endpoint, so a single global window is
+   * what actually backs us off — without it, the poll loop keeps firing new
+   * requests every few seconds, each gets 429'd, and the limit never clears.
+   */
+  private rateLimitedUntil = 0;
+  /** So a multi-minute window logs once, not once per gated poll. */
+  private rateLimitLogged = false;
 
   constructor(authStore: AuthStore) {
     this.authStore = authStore;
@@ -78,6 +86,24 @@ export class SpotifyStore {
       } else {
         delete this.requestQueue[cacheKey];
       }
+    }
+
+    // Honor a global rate-limit window. While Spotify has told us to back off,
+    // don't fire new requests and collect more 429s (which is what keeps the
+    // limit tripped); resolve undefined like every other failure here so the
+    // ~25 call sites keep their existing contract. Recent cached GETs are still
+    // served. Placed after the queue lookup so a request already in flight is
+    // joined rather than refused.
+    if (now < this.rateLimitedUntil) {
+      const entry =
+        method === "get" && !options.forceRefresh
+          ? this.requestCache[cacheKey]
+          : undefined;
+      if (entry && now - entry.timestamp < 60_000) return entry.data;
+      return undefined;
+    } else if (this.rateLimitLogged) {
+      this.rateLimitLogged = false;
+      console.info("SpotifyStore: rate-limit window cleared; resuming requests");
     }
 
     // Setup error handling
@@ -160,21 +186,44 @@ export class SpotifyStore {
             }
 
             if (response.status === 429) {
-              const retryAfter = parseInt(
-                response.headers.get("Retry-After") || "1",
-                10
+              // Open a global window so EVERY request backs off together, not
+              // just this one — that is what lets the limit actually clear.
+              // Retry-After may be seconds OR an HTTP-date (RFC 7231); a
+              // careless parse yields NaN, and `now < NaN` is always false,
+              // which would silently disable this entire mechanism.
+              const raw = response.headers.get("Retry-After");
+              let secs = Number.parseInt(raw ?? "", 10);
+              if (!Number.isFinite(secs) || secs <= 0) {
+                const asDate = raw ? Date.parse(raw) : NaN;
+                secs = Number.isFinite(asDate)
+                  ? Math.ceil((asDate - Date.now()) / 1000)
+                  : 5;
+              }
+              if (!Number.isFinite(secs) || secs <= 0) secs = 5;
+              // Clamp: Spotify has sent Retry-After values north of 13 hours.
+              // One probe per 5 minutes re-arms the window if the ban is truly
+              // longer, which beats a silent half-day freeze. Jitter avoids a
+              // thundering herd of pollers when the window lapses.
+              const MAX_BACKOFF_S = 300;
+              const delayMs =
+                Math.min(secs, MAX_BACKOFF_S) * 1000 +
+                Math.floor(Math.random() * 2000);
+              // Math.max: a concurrent 429 with a shorter Retry-After must
+              // never shrink an already-open window.
+              this.rateLimitedUntil = Math.max(
+                this.rateLimitedUntil,
+                Date.now() + delayMs
               );
-              this.rateLimitDelay = retryAfter * 1000;
-              console.debug(
-                `Rate limited. Waiting ${retryAfter} seconds before retry.`
-              );
-              await new Promise((resolve) =>
-                setTimeout(resolve, this.rateLimitDelay)
-              );
-              return this.makeRequest(method, url, data, {
-                forceRefresh: true,
-                attempt: retryCount + 1,
-              });
+              if (!this.rateLimitLogged) {
+                this.rateLimitLogged = true;
+                console.warn(
+                  `SpotifyStore: rate limited (429). Retry-After=${raw}; backing off all requests for ${Math.round(delayMs / 1000)}s`
+                );
+              }
+              // Resolve undefined (the contract every caller is written
+              // against) instead of retrying in place — the gate above lets
+              // the next poll through once the window passes.
+              return undefined;
             }
             throw new Error(`Request failed with status ${response.status}`);
           }

--- a/spotify/server/spotify/spotifyStore.ts
+++ b/spotify/server/spotify/spotifyStore.ts
@@ -75,8 +75,10 @@ export class SpotifyStore {
     const now = Date.now();
     const cacheTime = options.cacheTime ?? this.cacheExpiration;
 
-    // First check if the current request is in the queue
-    if (this.requestQueue[cacheKey]) {
+    // First check if the current request is in the queue. A forced refresh
+    // must not join it: the caller is asking precisely because it believes the
+    // in-flight answer is about to be out of date.
+    if (this.requestQueue[cacheKey] && !options.forceRefresh) {
       // Check the timestamp to ensure it hasn't expired
       if (this.requestQueue[cacheKey].timestamp + cacheTime > now) {
         console.debug(
@@ -299,6 +301,26 @@ export class SpotifyStore {
         promise: requestPromise,
         timestamp: now,
       };
+
+      // "Already in queue" has to mean "still in flight". Leaving the entry
+      // behind after the request settles turned this into a second, hidden
+      // cache — one that ignores forceRefresh and hands every later caller the
+      // resolved promise carrying the OLD payload for a further 3 seconds.
+      //
+      // That is what made a track boundary cost two poll cycles instead of
+      // one: the refresh at the boundary asks a beat too early and gets the
+      // track that just finished, its retries are answered from this stale
+      // promise, and the next scheduled poll lands in the same window and is
+      // answered from it too — so an entire cycle reports "no change" without
+      // ever reaching Spotify.
+      //
+      // requestCache below is the real cache and still coalesces ordinary
+      // rapid GETs, so nothing loses its de-duplication.
+      void requestPromise.finally(() => {
+        if (this.requestQueue[cacheKey]?.promise === requestPromise) {
+          delete this.requestQueue[cacheKey];
+        }
+      });
     }
 
     return requestPromise;
@@ -348,12 +370,15 @@ export class SpotifyStore {
     return this.responseCodeMap[code] || "Unknown Error";
   }
 
-  async getCurrentPlayback({ signal }: { signal?: AbortSignal } = {}): Promise<
+  async getCurrentPlayback({
+    signal,
+    forceRefresh,
+  }: { signal?: AbortSignal; forceRefresh?: boolean } = {}): Promise<
     PlayerResponse | undefined
   > {
     console.debug("SpotifyStore: getCurrentPlayback");
     const url = `${this.BASE_URL}?additional_types=episode`;
-    return this.makeRequest("get", url, undefined, { signal });
+    return this.makeRequest("get", url, undefined, { signal, forceRefresh });
   }
 
   async getPlaylists(start = 0, limit = 20): Promise<PlaylistsResponse | undefined> {

--- a/spotify/src/App.tsx
+++ b/spotify/src/App.tsx
@@ -1,27 +1,28 @@
 import React from "react";
 import Player from "./Pages/Player";
-import { PanelManager } from "./panels/PanelManager";
 import { ControlProvider } from "./providers/ControlProvider";
 import { MusicProvider } from "./providers/MusicProvider";
 import { QueueProvider } from "./providers/QueueProvider";
 import { SettingsProvider } from "./providers/SettingsProvider";
 import { UIProvider } from "./providers/UIProvider";
-import { PlaylistProvider } from "./providers/PlaylistProvider";
+
+// Playlists live in a zustand store (src/stores/playlistStore.ts), not a
+// provider — every consumer reaches for usePlaylistStore directly. The
+// PlaylistProvider this file used to wrap was deleted in that migration but the
+// import stayed, so the app has not compiled since.
 
 const App: React.FC = () => {
   return (
     <div className="max-w-screen max-h-screen">
       <SettingsProvider>
         <MusicProvider>
-          <PlaylistProvider>
-            <QueueProvider>
-              <ControlProvider>
-                <UIProvider>
-                  <Player />
-                </UIProvider>
-              </ControlProvider>
-            </QueueProvider>
-          </PlaylistProvider>
+          <QueueProvider>
+            <ControlProvider>
+              <UIProvider>
+                <Player />
+              </UIProvider>
+            </ControlProvider>
+          </QueueProvider>
         </MusicProvider>
       </SettingsProvider>
     </div>


### PR DESCRIPTION
# Fix Spotify rate limiting: honor Retry-After globally, stop redundant calls

## The bug

The 429 handler slept inside the request that got rate-limited and then retried it in place — but nothing gated **other** requests. DeskThing's music poller kept firing every 15s, each call collected another 429, and the ban window never cleared. There was also no `retryCount < MAX_RETRIES` guard on that path, unlike the 401 path.

Captured live on my setup:

- **134 consecutive 429s over 2h11m**, at a steady 15.007s interval
- Spotify's `Retry-After` counted down **8008s → 158s in lockstep with the polling** — decrementing by exactly 15 each cycle, which is direct proof the wait was never actually honored
- The app served empty song data to the device the whole time (it renders as a blank "undefined cover" screen on a Car Thing)

## The fix

**A single global backoff window** (`rateLimitedUntil`), because Spotify's 429 applies to the whole app, not one endpoint:

- **NaN-proof `Retry-After` parsing.** RFC 7231 allows an HTTP-date, and `parseInt("Wed, 05 Aug 2026 15:00:00 GMT")` is `NaN` — and `now < NaN` is *always false*, which would silently disable the entire mechanism forever. Both forms are parsed; zero/negative/garbage fall back to 5s.
- **Clamped to 300s.** The logs contain `Retry-After: 47967` (13.3 hours). Unclamped, the app goes silently dead for half a day. One probe request every 5 minutes re-arms the window if the ban really is longer — self-correcting, and far better than a half-day freeze.
- **`Math.max`, never a plain assignment.** Four pollers run concurrently (song, queue, device, playlist). Without this, a 429 carrying `Retry-After: 1` arriving 50ms after one carrying `60` collapses the window to 1s and the app instantly re-trips.
- **Jitter**, so every poller doesn't unblock on the same millisecond when the window lapses.
- **Gate placed after the in-flight queue lookup**, so a request already underway is joined rather than refused.
- **Resolves `undefined`** — the contract all ~25 call sites are already written against — instead of introducing a second failure signal. It also serves cached GETs up to 60s old, so the UI shows the last-known track instead of going blank during a window.
- **Logs once per window**, not once per gated poll, with a matching "window cleared" line on recovery.

## Also: the traffic that trips the limit

Two changes cut steady-state API calls by ~3×:

- **`checkLiked` was firing on every single 15s poll.** `checkForRefresh` treats a progress delta > 3000ms as a state change — but a 15s poll *always* advances progress by ~15000ms, so `stateChanged` was permanently true. That made `/me/tracks/contains` a third of all API traffic, and it's the endpoint that absorbed every recorded 429 and 403. Now memoized per track (5-minute TTL), invalidated by `likeSong` so the like toggle stays instant.
- **The queue cache TTL was 10s under a 15s poll**, guaranteeing a live call every cycle. Raised to 45s.

## Verification

Measured on a live install with music playing, over a 5-minute window after the fix:

| | before | after |
| --- | --- | --- |
| API requests | 12/min | **4/min** |
| `/me/tracks/contains` | every 15s cycle | **0** (only on track change) |
| 429s | continuous | **0** |

The `Retry-After` parse is unit-tested out-of-process against `"120"`, `"0"`, `"-1"`, `null`, `""`, `"47967"`, `"garbage"`, and both future and past HTTP-date forms — every case yields a finite window in `(now, now+302s]`. The never-shrink property is tested by firing a 60s window followed by a 1s one.

Typecheck passes; the server bundles cleanly with esbuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
