### PR TITLE
fix(spotify): transfer playback when no device is active

### DIFF
--- a/spotify/server/spotify/actionStore.ts
+++ b/spotify/server/spotify/actionStore.ts
@@ -98,6 +98,27 @@ export class ActionStore {
         });
       }
       console.debug('Resuming current song');
+
+      const settings = await DeskThing.getSettings();
+      const outputDevice = settings?.[SpotifySettingIDs.OUTPUT_DEVICE]?.value;
+      const transferPlaybackOnError =
+        settings?.[SpotifySettingIDs.TRANSFER_PLAYBACK_ON_ERROR]?.value;
+
+      if (
+        transferPlaybackOnError === true &&
+        typeof outputDevice === "string" &&
+        outputDevice !== "default"
+      ) {
+        const playback = await this.spotifyApi.getCurrentPlayback();
+
+        if (!playback) {
+          console.debug(
+            `Transferring playback to configured output device: ${outputDevice}`
+          );
+          return this.spotifyApi.transferPlayback(outputDevice);
+        }
+      }
+
       return this.spotifyApi.play();
     } catch (error) {
       console.error("Error playing:", error);


### PR DESCRIPTION
## Summary

Recover context-less Play commands when Spotify has no active playback device.

When `transfer_playback_on_error` is enabled and a non-default `output_device` is configured, the Spotify app now checks for active playback before resuming. If none exists, it uses the existing `transferPlayback(deviceId)` path, which transfers playback to the configured device with `play: true`.

Normal Play behavior is preserved when playback is already active, the output is set to Default, recovery is disabled, or a track/playlist context was supplied.

## Reproduction

1. Configure a Spotify Connect device as DeskThing's output.
2. Play Spotify on that device.
3. Transfer playback to another device.
4. Close Spotify on the other device so no playback device remains active.
5. Press Play on Car Thing.

Previously, DeskThing called `PUT /v1/me/player/play`, which returned 404 because no device was active.

## Testing

- Confirmed the equivalent transfer behavior against Spotify app 0.11.1 with a Spotify Connect output.
- Ran `npm run build-server` successfully.